### PR TITLE
fix: fixed undefined region in config file

### DIFF
--- a/src/get-credentials.ts
+++ b/src/get-credentials.ts
@@ -41,15 +41,15 @@ export const processSelectedRole = async (selectedRole: string) => {
 const writeFile = (credentials: any) => {
     const filePath = homedir + '/.aws/credentials';
     const file = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
-    const config = ini.parse(file);
-    config.okta = {
+    const configFile = ini.parse(file);
+    configFile.okta = {
         aws_access_key_id: credentials.AccessKeyId,
         aws_secret_access_key: credentials.SecretAccessKey,
         aws_session_token: credentials.SessionToken,
         region: config.AWS_REGION,
         token_expiration: credentials.Expiration?.toISOString(),
     };
-    fs.writeFileSync(filePath, ini.stringify(config));
+    fs.writeFileSync(filePath, ini.stringify(configFile));
 }
 
 const getAssumableRoles = async (win: BrowserWindow): Promise<IAssumableRole[]> => {

--- a/src/get-credentials.ts
+++ b/src/get-credentials.ts
@@ -4,7 +4,6 @@ import { getConfig } from "./config"
 import { homedir } from "os";
 import fs from "fs";
 import ini from "ini";
-import path from "path";
 
 const config = getConfig();
 


### PR DESCRIPTION
Changed `configFile` parameter name to avoid it being overwritten in `writeFile` function and causing an undefined reference for `config.AWS_REGION`